### PR TITLE
Provide version bounds for aioredis

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     """,
     install_requires=[
         'async-timeout>=3.0.0',
-        'aioredis>=1.1.0',
+        'aioredis>=1.1.0,<2.0.0',
         'click>=6.7',
         'pydantic>=0.20',
         'dataclasses>=0.6;python_version == "3.6"'


### PR DESCRIPTION
Related to https://github.com/samuelcolvin/arq/pull/258 on arq - they have provided version bound on aioredis for now.

aioredis 2.0.0. is giving Import Error. 
```ImportError: cannot import name 'MultiExecError' from 'aioredis'```
2.0 aioredis release, the naming/location of the module's exceptions/ other module internals have changed.